### PR TITLE
add .gg and .sms to extractable rom list

### DIFF
--- a/ssnes-phoenix.cpp
+++ b/ssnes-phoenix.cpp
@@ -841,9 +841,9 @@ class MainWindow : public Window
             ".smc", ".sfc",
             ".nes",
             ".gba", ".gb", ".gbc",
-				// full list of pre-dreamcast sega rom file extensions: .bin, .gen, .md, .smd, .mdx, .sms, .gg, .sg
-				// Genesis-next-libsnes extensions are below.  Genplus-gx supports the full list above, so they should probably be added at some point.
-				// Perhaps it would be prudent to add them now so that ROM load failure is up to the emulator core rather than this unzipping list.
+            // full list of pre-dreamcast sega rom file extensions: .bin, .gen, .md, .smd, .mdx, .sms, .gg, .sg
+            // Genesis-next-libsnes extensions are below.  Genplus-gx supports the full list above, so they should probably be added at some point.
+            // Perhaps it would be prudent to add them now so that ROM load failure is up to the emulator core rather than this unzipping list.
             ".bin", ".gen", ".md", ".smd", ".sms", ".gg"
          };
 

--- a/ssnes-phoenix.cpp
+++ b/ssnes-phoenix.cpp
@@ -841,7 +841,10 @@ class MainWindow : public Window
             ".smc", ".sfc",
             ".nes",
             ".gba", ".gb", ".gbc",
-            ".bin", ".smd", ".gen", ".md",
+				// full list of pre-dreamcast sega rom file extensions: .bin, .gen, .md, .smd, .mdx, .sms, .gg, .sg
+				// Genesis-next-libsnes extensions are below.  Genplus-gx supports the full list above, so they should probably be added at some point.
+				// Perhaps it would be prudent to add them now so that ROM load failure is up to the emulator core rather than this unzipping list.
+            ".bin", ".gen", ".md", ".smd", ".sms", ".gg"
          };
 
          foreach (file, z.file)


### PR DESCRIPTION
.gg and .sms are both loadable with genesis-next-libsnes, according to almostalive.

Also, perhaps it would be prudent to add the full list of rom extensions as stated in the comment.
