### PR TITLE
Fix compilation failure on Debian Squeeze (and perhaps Ubuntu 10.04)

### DIFF
--- a/phoenix/phoenix.cpp
+++ b/phoenix/phoenix.cpp
@@ -30,8 +30,19 @@
   #include <gdk/gdk.h>
   #include <gdk/gdkx.h>
   #include <cairo.h>
-  #include <gdk/gdkkeysyms.h>
   #include <X11/Xatom.h>
+  #include <gdk/gdkkeysyms.h>
+
+  // Support legacy version of gdk/gdkkeysyms.h (Debian Squeeze, Ubuntu 10.04 
+  // among others)
+  #ifndef GDK_KEY_Home
+  #define GDK_KEY_Home GDK_Home
+  #define GDK_KEY_End GDK_End
+  #define GDK_KEY_Up GDK_Up
+  #define GDK_KEY_Down GDK_Down
+  #define GDK_KEY_Page_Up GDK_Page_Up
+  #define GDK_KEY_Page_Down GDK_Page_Down
+  #endif
 
   #undef None
   #undef Window


### PR DESCRIPTION
Debian Squeeze ships with an outdated version of libgtk2.0-dev. Sometime between Squeeze's release and today the naming convention in gdk/gdkkeysyms.h changed which means Phoenix won't compile on Squeeze without this patch. It's not particularly pretty but it does the job.
